### PR TITLE
Update dwf_funcs.py for demod filter

### DIFF
--- a/lab10/dwf_funcs.py
+++ b/lab10/dwf_funcs.py
@@ -661,7 +661,7 @@ def _run_acquistion(
                 time_sample=time_sample,
                 record=record,
                 analog_out_frequency=analog_out_frequency,
-                record_length_time=record_length_time
+                analog_in_frequency=analog_in_frequency
             )
 
             lines_voltage_raw, line_fft_raw = _plot_raw_or_demod(
@@ -919,7 +919,7 @@ def _calc_demod(
     time_sample: NDArray[np.float64],
     record: NDArray[np.float64],
     analog_out_frequency: float,
-    record_length_time: float
+    analog_in_frequency: float
     ) -> tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]:
     '''
     Perform demodulation calculations and filtering.
@@ -936,7 +936,7 @@ def _calc_demod(
     ##
 
     # How many samples need to be averaged to give a nu_3db rolloff?
-    n_filt = round(nu_3db * record_length_time)
+    n_filt = round(analog_in_frequency/nu_3dB)
 
     # Put a simple 1pole low-pass filter on it
     # You can also use the scipy python package to get more advanced filters


### PR DESCRIPTION
This fixes a bug in the calc_demod() function, which is supposed to low pass the demod signal with nu_3dB as its cutoff frequency. The filter works a s a moving average: signals that have a period larger than n_filt will be averaged out and thus filtered out. For this to work properly, we need n_filt (~period to be filtered out) to be inversely proportional to nu_3dB (~frequency = 1/period), while previously n_filt is proportional to nu_3dB. 